### PR TITLE
Run the non-global binary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ async function main() {
 }
 
 import { fileURLToPath } from 'node:url';
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (await fs.promises.realpath(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main();
 }
 


### PR DESCRIPTION
Npx caches binaries in temp directory with symlinks,
so symlink of the entry file need to be resolved for the comparison to work.

Fixes #2 